### PR TITLE
remove watermark when dragging out a view

### DIFF
--- a/styles/frame-styles.css
+++ b/styles/frame-styles.css
@@ -79,3 +79,7 @@ body {
     width: 100%;
     height: auto;
 }
+
+.wrapper_title {
+  display: none !important;
+}


### PR DESCRIPTION
.wrapper_title {
  display: none !important;
}