### PR TITLE
add hideTab functionality

### DIFF
--- a/default-snapshot.json
+++ b/default-snapshot.json
@@ -3,7 +3,8 @@
         "windows": [
             {
                 "url": "http://localhost:5555/main-window.html",
-                "layout": {
+                "name": "SC-main-window",
+                "layout": {      
                     "content": [
                         {
                             "type": "stack",

--- a/js/main-window.js
+++ b/js/main-window.js
@@ -165,7 +165,45 @@ class TitleBar extends HTMLElement {
         
         fin.Window.getCurrentSync().on('close-requested', () => {
             this.closeAll();
-        });    
+        });
+
+        fin.Window.getCurrentSync().on('view-attached', () => {
+            this.hideTabsIfOnlyOneTabPresent()
+        });
+
+        fin.Window.getCurrentSync().on('view-detached', () => {
+            this.hideTabsIfOnlyOneTabPresent()
+        });
+    }
+
+    async hideTabsIfOnlyOneTabPresent() {
+        const myWin = fin.Window.getCurrentSync()
+        const viewsArray = await myWin.getCurrentViews();
+        const oldLayout = await fin.Platform.Layout.getCurrentSync().getConfig();
+        const { settings, dimensions } = oldLayout;
+        if (viewsArray.length === 1) {
+            if (settings.hasHeaders) {
+                fin.Platform.Layout.getCurrentSync().replace({
+                    ...oldLayout,
+                    settings: {
+                        ...settings,
+                        hasHeaders: false
+                    }
+                });
+            }
+        } else if (!settings.hasHeaders) {
+            fin.Platform.Layout.getCurrentSync().replace({
+                ...oldLayout,
+                settings: {
+                    ...settings,
+                    hasHeaders: true
+                },
+                dimensions: {
+                    ...dimensions,
+                    headerHeight: 20
+                }
+            });
+        }
     }
 
     async render() {


### PR DESCRIPTION
This PR shows off two things:

1. It was previously stated that you can't attach a name to the platform windows. You actually can, by including the `name` property in the snapshot.
2. Besides that, here is an example of something you can do to hide the tabs in the "main window" when there is only 1 tab present. This prevents a user from dragging out that tab, which prevents that main window from closing. 